### PR TITLE
Now using python-shell for inter-process communication

### DIFF
--- a/class.Screen.js
+++ b/class.Screen.js
@@ -1,9 +1,19 @@
+import { PythonShell }  from 'python-shell'
+
+let display = new PythonShell('display.py', {
+  pythonOptions: ['-u']
+})
+
 class Screen {
   constructor(location = 'images/'){
     this.counter = 0
     this.limit = 10
     this.location = location
-    this.render = this.display
+    this.render = this.shell
+  }
+
+  shell (p = this.p, canvas=this.canvas) {
+    display.send(canvas.canvas.toDataURL())
   }
 
   display (p = this.p, canvas=this.canvas) {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "quadratura",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "description": "A sample app for the Quadratura project",
   "main": "index.js",
   "scripts": {
     "start": "node sketch.js",
-    "display": "node sketch.js | python display.py",
-    "example": "node sketch-example.js | python display.py",
+    "display": "node sketch.js",
+    "example": "node sketch-example.js",
     "clean": "rm -rf ./output/*"
   },
   "type": "module",


### PR DESCRIPTION
This modifies `npm run display` to only run node, which in turn uses `python-shell` to manage sending data to `display.py`, rather than having to manually pipe data from one process to another.